### PR TITLE
MSQ-18: Prevent albums expanding before data loads

### DIFF
--- a/musiquia/src/components/AlbumsTab.js
+++ b/musiquia/src/components/AlbumsTab.js
@@ -6,6 +6,7 @@ function AlbumsTab({requestToken, userInfo}) {
   const [albums, setAlbums] = useState([]);
   const [likedTracks, setLikedTracks] = useState([]);
   const [otherUsersLiked, setOtherUsersLiked] = useState([]);
+  const [userLikesFetched, setUserLikesFetched] = useState(false);
   let trackPlayCallback = undefined;
 
   useEffect(() => {
@@ -21,6 +22,7 @@ function AlbumsTab({requestToken, userInfo}) {
       setOtherUsersLiked(data.likedTracks);
       const userLikes = data.likedTracks.filter(track => track.likedBy.includes(userInfo.id));
       setLikedTracks(userLikes.map(track => track.id));
+      setUserLikesFetched(true);
     }
 
     async function fetchAlbums() {
@@ -106,6 +108,7 @@ function AlbumsTab({requestToken, userInfo}) {
               playTrack={playTrack}
               pauseTrack={pauseTrack}
               otherLikes={otherUsersLiked}
+              readyToOpen={userLikesFetched}
             />
           );
         })}

--- a/musiquia/src/components/Record.js
+++ b/musiquia/src/components/Record.js
@@ -18,6 +18,9 @@ function Record(props) {
   }
 
   async function toggleTracks(event) {
+    if (!props.readyToOpen) {
+      return;
+    }
     if (tracksVisible) {
       setTracksVisible(false);
     }


### PR DESCRIPTION
# What does this pull request do?

Prevent albums in the AlbumsTab from expanding before all of the 'likes' data has loaded