### PR TITLE
MSQ-20: Increase track limit on albums

### DIFF
--- a/musiquia/src/components/Record.js
+++ b/musiquia/src/components/Record.js
@@ -37,7 +37,7 @@ function Record(props) {
         'Authorization': 'Bearer ' + getLocalToken()
       }
     }
-    const response = await fetch("https://api.spotify.com/v1/albums/" + props.albumID + "/tracks", queryParameters);
+    const response = await fetch("https://api.spotify.com/v1/albums/" + props.albumID + "/tracks?limit=50", queryParameters);
     if (response.status === 200) {
       const data = await response.json();
       const tracks = data.items.map(track => ({"name": track.name, "id": track.id, "preview": track.preview_url}));


### PR DESCRIPTION
# What does this Pull Request do?

Increase the limit on the number of tracks retrieved per album from the Spotify API

Limit increased from 20 to 50